### PR TITLE
fix: randomize starting player while maintaining input order

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import Standings from '../components/Standings';
 import RulesModal from '../components/RulesModal';
 import { saveGameState, loadGameState, clearGameState } from '../utils/gameStorage';
 import { sortPlayerRankings } from '../utils/playerSorting';
-import { shuffleArray } from '../utils/playerOrder';
+import { rotateToRandomStart } from '../utils/playerOrder';
 
 export default function FiveCrownsScorekeeper() {
   const [players, setPlayers] = useState<Player[]>([]);
@@ -87,8 +87,8 @@ export default function FiveCrownsScorekeeper() {
     // Initialize player order when adding the first round
     if (rounds.length === 0) {
       setShowPlayerManagement(false);
-      const shuffledOrder = shuffleArray(players.map(p => p.id));
-      setPlayerOrder(shuffledOrder);
+      const rotatedOrder = rotateToRandomStart(players.map(p => p.id));
+      setPlayerOrder(rotatedOrder);
     }
   };
 

--- a/src/utils/__tests__/playerOrder.test.ts
+++ b/src/utils/__tests__/playerOrder.test.ts
@@ -1,47 +1,82 @@
-import { shuffleArray, getCurrentTurnPlayer } from '../playerOrder';
+import { rotateToRandomStart, getCurrentTurnPlayer } from '../playerOrder';
 
-describe('shuffleArray', () => {
+describe('rotateToRandomStart', () => {
   it('returns array with same length', () => {
     const input = ['a', 'b', 'c', 'd'];
-    const result = shuffleArray(input);
+    const result = rotateToRandomStart(input);
     expect(result).toHaveLength(input.length);
   });
 
   it('contains all original elements', () => {
     const input = ['a', 'b', 'c', 'd'];
-    const result = shuffleArray(input);
+    const result = rotateToRandomStart(input);
     expect(result.sort()).toEqual(input.sort());
+  });
+
+  it('maintains circular order', () => {
+    // Run multiple times to test different rotations
+    const input = ['a', 'b', 'c', 'd'];
+
+    for (let i = 0; i < 20; i++) {
+      const result = rotateToRandomStart(input);
+
+      // Find where 'a' is in the result
+      const aIndex = result.indexOf('a');
+
+      // Check that elements follow in circular order
+      expect(result[(aIndex + 1) % 4]).toBe('b');
+      expect(result[(aIndex + 2) % 4]).toBe('c');
+      expect(result[(aIndex + 3) % 4]).toBe('d');
+    }
   });
 
   it('does not mutate original array', () => {
     const input = ['a', 'b', 'c', 'd'];
     const original = [...input];
-    shuffleArray(input);
+    rotateToRandomStart(input);
     expect(input).toEqual(original);
   });
 
   it('handles empty array', () => {
-    const result = shuffleArray([]);
+    const result = rotateToRandomStart([]);
     expect(result).toEqual([]);
   });
 
   it('handles single element', () => {
-    const result = shuffleArray(['a']);
+    const result = rotateToRandomStart(['a']);
     expect(result).toEqual(['a']);
   });
 
-  it('produces different orderings (probabilistic test)', () => {
-    // Run shuffle 100 times and check that we get at least one different ordering
+  it('produces different starting positions (probabilistic test)', () => {
+    // Run rotation 100 times and check that we get different starting positions
     const input = ['a', 'b', 'c', 'd', 'e'];
     const results = new Set();
 
     for (let i = 0; i < 100; i++) {
-      const shuffled = shuffleArray(input);
-      results.add(shuffled.join(','));
+      const rotated = rotateToRandomStart(input);
+      results.add(rotated.join(','));
     }
 
-    // With 5 elements, we should get multiple different orderings
+    // With 5 elements, we should get multiple different rotations (up to 5 possible)
     expect(results.size).toBeGreaterThan(1);
+  });
+
+  it('all possible rotations are valid', () => {
+    const input = ['a', 'b', 'c', 'd'];
+    const validRotations = [
+      ['a', 'b', 'c', 'd'],
+      ['b', 'c', 'd', 'a'],
+      ['c', 'd', 'a', 'b'],
+      ['d', 'a', 'b', 'c']
+    ];
+
+    // Run multiple times to increase chance of hitting all rotations
+    for (let i = 0; i < 20; i++) {
+      const result = rotateToRandomStart(input);
+      const resultString = result.join(',');
+      const isValid = validRotations.some(rotation => rotation.join(',') === resultString);
+      expect(isValid).toBe(true);
+    }
   });
 });
 

--- a/src/utils/playerOrder.ts
+++ b/src/utils/playerOrder.ts
@@ -1,13 +1,13 @@
 /**
- * Shuffle an array using Fisher-Yates algorithm
+ * Rotate an array to start from a random position
+ * Maintains the original circular order but randomizes who starts first
+ * @param array - The array to rotate
+ * @returns A new array rotated to start from a random position
  */
-export function shuffleArray<T>(array: T[]): T[] {
-  const shuffled = [...array];
-  for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-  }
-  return shuffled;
+export function rotateToRandomStart<T>(array: T[]): T[] {
+  if (array.length === 0) return [];
+  const startIndex = Math.floor(Math.random() * array.length);
+  return [...array.slice(startIndex), ...array.slice(0, startIndex)];
 }
 
 /**


### PR DESCRIPTION
Replace full player order shuffling with rotation from a random starting position. This maintains the original player order as inputted by the user while randomizing who goes first.

Changes:
- Replace shuffleArray with rotateToRandomStart function
- Update playerOrder.ts to rotate array from random starting index
- Maintain circular order (e.g., [A,B,C,D] becomes [C,D,A,B] if starting at C)
- Update all tests to verify circular order is maintained
- Add test to verify all rotations are valid

The turn rotation still works the same way, but now respects the original player input order instead of fully randomizing the sequence.